### PR TITLE
Add support for the i8 type

### DIFF
--- a/syntax/thrift.vim
+++ b/syntax/thrift.vim
@@ -51,7 +51,7 @@ syn match thriftNumber "-\=\<\d\+\>" contained
 syn keyword thriftKeyword namespace
 syn keyword thriftKeyword xsd_all xsd_optional xsd_nillable xsd_attrs
 syn keyword thriftKeyword include cpp_include cpp_type const optional required
-syn keyword thriftBasicTypes void bool byte i16 i32 i64 double string binary
+syn keyword thriftBasicTypes void bool byte i8 i16 i32 i64 double string binary
 syn keyword thriftStructure map list set struct typedef exception enum throws union
 
 " Special


### PR DESCRIPTION
This adds support for the `i8` type in Thrift. `i8` is the explicit type for `byte` and is recommended in Thrift 0.10.0 to be used over `byte` to emphasize the signedness.

Example warning from Thrift 0.10.0

> The "byte" type is a compatibility alias for "i8". Use "i8" to emphasize the signedness of this type.